### PR TITLE
Rename Eventer and allow definition of listener methods by name

### DIFF
--- a/EventListener.lua
+++ b/EventListener.lua
@@ -43,6 +43,9 @@ function EventListener:listenManyEvents(listeners, prefix)
         if Utils.isCallable(value) then
             --callable, register listener
             self:listenEvent(prefix, value)
+        elseif Utils.isCallable(self[value]) then
+            --method name, register listener
+            self:listenEvent(prefix, self[value])
         else
             --sub event table, continue recursively
             self:listenManyEvents(value, prefix)
@@ -59,6 +62,9 @@ function EventListener:listenManyRequests(listeners, prefix)
         if Utils.isCallable(value) then
             --callable, register listener
             self:listenRequest(prefix, value)
+        elseif Utils.isCallable(self[value]) then
+            --method name, register listener
+            self:listenRequest(prefix, self[value])
         else
             --sub event table, continue recursively
             self:listenManyRequests(value, prefix)

--- a/EventListener.lua
+++ b/EventListener.lua
@@ -1,12 +1,12 @@
 --[[
-    Wraps Event methods in a instantiable Class.
+    Wraps Event listening methods into a instantiable Class.
     This makes it easier to create children classes that already have communication methods implemented.
 ]]
 local Utils = require("YfritLib.Utils")
 local Class = require("YfritLib.Class")
 local Event = require("EventSystem.Event")
 
-local Eventer =
+local EventListener =
     Class.new(
     {},
     function(self)
@@ -21,25 +21,25 @@ local Eventer =
     end
 )
 
-function Eventer:broadcast(...)
+function EventListener:broadcast(...)
     Event.broadcast(...)
 end
 
-function Eventer:listenEvent(event, method)
+function EventListener:listenEvent(event, method)
     local function methodWithSelf(...)
         method(self, ...)
     end
     Event.listenEvent(event, methodWithSelf)
 end
 
-function Eventer:listenRequest(event, method)
+function EventListener:listenRequest(event, method)
     local function methodWithSelf(...)
         method(self, ...)
     end
     Event.listenRequest(event, methodWithSelf)
 end
 
-function Eventer:listenManyEvents(listeners, prefix)
+function EventListener:listenManyEvents(listeners, prefix)
     prefix = prefix or {}
     local index = #prefix + 1
     for event, value in pairs(listeners) do
@@ -55,7 +55,7 @@ function Eventer:listenManyEvents(listeners, prefix)
     prefix[index] = nil
 end
 
-function Eventer:listenManyRequests(listeners, prefix)
+function EventListener:listenManyRequests(listeners, prefix)
     prefix = prefix or {}
     local index = #prefix + 1
     for event, value in pairs(listeners) do
@@ -71,4 +71,4 @@ function Eventer:listenManyRequests(listeners, prefix)
     prefix[index] = nil
 end
 
-return Eventer
+return EventListener

--- a/EventListener.lua
+++ b/EventListener.lua
@@ -21,10 +21,6 @@ local EventListener =
     end
 )
 
-function EventListener:broadcast(...)
-    Event.broadcast(...)
-end
-
 function EventListener:listenEvent(event, method)
     local function methodWithSelf(...)
         method(self, ...)

--- a/eventsystem-scm-1.rockspec
+++ b/eventsystem-scm-1.rockspec
@@ -15,6 +15,6 @@ build = {
    type = "builtin",
    modules = {
       ["EventSystem.Event"] = "Event.lua",
-      ["EventSystem.Eventer"] = "Eventer.lua",
+      ["EventSystem.EventListener"] = "EventListener.lua",
    }
 }

--- a/spec/EventListener_spec.lua
+++ b/spec/EventListener_spec.lua
@@ -41,18 +41,6 @@ describe(
         )
 
         it(
-            ":broadcast(...) calls Event.broadcast(...)",
-            function()
-                spy.on(Event, "broadcast")
-
-                local eventListener = EventListener:new()
-                eventListener:broadcast("SubEvent1", "SubEvent2", "SubEvent3")
-
-                assert.spy(Event.broadcast).was_called_with("SubEvent1", "SubEvent2", "SubEvent3")
-            end
-        )
-
-        it(
             ":listenEvent injects self into Event.listenEvent",
             function()
                 spy.on(Event, "listenEvent")

--- a/spec/EventListener_spec.lua
+++ b/spec/EventListener_spec.lua
@@ -6,20 +6,20 @@ assert:register(
     "has_self",
     function(state, arguments)
         local method = arguments[1]
-        local eventer = arguments[2]
+        local eventListener = arguments[2]
         return function(methodWithSelf)
             methodWithSelf()
-            assert.spy(method).was_called_with(eventer)
+            assert.spy(method).was_called_with(eventListener)
             return true
         end
     end
 )
 
 describe(
-    "Eventer",
+    "EventListener",
     function()
         local Event
-        local Eventer
+        local EventListener
         local Class
 
         setup(
@@ -30,13 +30,13 @@ describe(
         before_each(
             function()
                 Event = mockRequire("Event")
-                Eventer = require("Eventer")
+                EventListener = require("EventListener")
             end
         )
         after_each(
             function()
                 unrequire("Event")
-                unrequire("Eventer")
+                unrequire("EventListener")
             end
         )
 
@@ -45,8 +45,8 @@ describe(
             function()
                 spy.on(Event, "broadcast")
 
-                local eventer = Eventer:new()
-                eventer:broadcast("SubEvent1", "SubEvent2", "SubEvent3")
+                local eventListener = EventListener:new()
+                eventListener:broadcast("SubEvent1", "SubEvent2", "SubEvent3")
 
                 assert.spy(Event.broadcast).was_called_with("SubEvent1", "SubEvent2", "SubEvent3")
             end
@@ -57,15 +57,15 @@ describe(
             function()
                 spy.on(Event, "listenEvent")
 
-                local eventer = Eventer:new()
+                local eventListener = EventListener:new()
                 local method =
                     spy.new(
                     function()
                     end
                 )
-                eventer:listenEvent({"Event"}, method)
+                eventListener:listenEvent({"Event"}, method)
 
-                assert.spy(Event.listenEvent).was_called_with({"Event"}, match.has_self(method, eventer))
+                assert.spy(Event.listenEvent).was_called_with({"Event"}, match.has_self(method, eventListener))
             end
         )
 
@@ -74,15 +74,15 @@ describe(
             function()
                 spy.on(Event, "listenRequest")
 
-                local eventer = Eventer:new()
+                local eventListener = EventListener:new()
                 local method =
                     spy.new(
                     function()
                     end
                 )
-                eventer:listenRequest({"Event"}, method)
+                eventListener:listenRequest({"Event"}, method)
 
-                assert.spy(Event.listenRequest).was_called_with({"Event"}, match.has_self(method, eventer))
+                assert.spy(Event.listenRequest).was_called_with({"Event"}, match.has_self(method, eventListener))
             end
         )
 
@@ -91,7 +91,7 @@ describe(
             function()
                 spy.on(Event, "listenEvent")
 
-                local eventer = Eventer:new()
+                local eventListener = EventListener:new()
                 local method1 =
                     spy.new(
                     function()
@@ -107,7 +107,7 @@ describe(
                     function()
                     end
                 )
-                eventer:listenManyEvents(
+                eventListener:listenManyEvents(
                     {
                         Event1 = {
                             SubEvent1 = method1
@@ -120,9 +120,18 @@ describe(
                 )
 
                 assert.spy(Event.listenEvent).was_called(3)
-                assert.spy(Event.listenEvent).was_called_with({"Event1", "SubEvent1"}, match.has_self(method1, eventer))
-                assert.spy(Event.listenEvent).was_called_with({"Event2", "SubEvent2"}, match.has_self(method2, eventer))
-                assert.spy(Event.listenEvent).was_called_with({"Event2", "SubEvent3"}, match.has_self(method3, eventer))
+                assert.spy(Event.listenEvent).was_called_with(
+                    {"Event1", "SubEvent1"},
+                    match.has_self(method1, eventListener)
+                )
+                assert.spy(Event.listenEvent).was_called_with(
+                    {"Event2", "SubEvent2"},
+                    match.has_self(method2, eventListener)
+                )
+                assert.spy(Event.listenEvent).was_called_with(
+                    {"Event2", "SubEvent3"},
+                    match.has_self(method3, eventListener)
+                )
             end
         )
 
@@ -131,7 +140,7 @@ describe(
             function()
                 spy.on(Event, "listenRequest")
 
-                local eventer = Eventer:new()
+                local eventListener = EventListener:new()
                 local method1 =
                     spy.new(
                     function()
@@ -147,7 +156,7 @@ describe(
                     function()
                     end
                 )
-                eventer:listenManyRequests(
+                eventListener:listenManyRequests(
                     {
                         Event1 = {
                             SubEvent1 = method1
@@ -162,15 +171,15 @@ describe(
                 assert.spy(Event.listenRequest).was_called(3)
                 assert.spy(Event.listenRequest).was_called_with(
                     {"Event1", "SubEvent1"},
-                    match.has_self(method1, eventer)
+                    match.has_self(method1, eventListener)
                 )
                 assert.spy(Event.listenRequest).was_called_with(
                     {"Event2", "SubEvent2"},
-                    match.has_self(method2, eventer)
+                    match.has_self(method2, eventListener)
                 )
                 assert.spy(Event.listenRequest).was_called_with(
                     {"Event2", "SubEvent3"},
-                    match.has_self(method3, eventer)
+                    match.has_self(method3, eventListener)
                 )
             end
         )
@@ -178,8 +187,8 @@ describe(
         it(
             "child can use listener attribute to set instance listeners",
             function()
-                spy.on(Eventer, "listenManyEvents")
-                spy.on(Eventer, "listenManyRequests")
+                spy.on(EventListener, "listenManyEvents")
+                spy.on(EventListener, "listenManyRequests")
                 local mockMethod = function()
                 end
                 local ChildClass =
@@ -208,12 +217,12 @@ describe(
                     },
                     function(self)
                     end,
-                    Eventer
+                    EventListener
                 )
 
                 local instance = ChildClass:new()
 
-                assert.spy(Eventer.listenManyEvents).was_called_with(
+                assert.spy(EventListener.listenManyEvents).was_called_with(
                     instance,
                     {
                         Event1 = {
@@ -225,7 +234,7 @@ describe(
                         }
                     }
                 )
-                assert.spy(Eventer.listenManyRequests).was_called_with(
+                assert.spy(EventListener.listenManyRequests).was_called_with(
                     instance,
                     {
                         Event3 = {
@@ -238,8 +247,8 @@ describe(
                     }
                 )
 
-                Eventer.listenManyEvents:revert()
-                Eventer.listenManyRequests:revert()
+                EventListener.listenManyEvents:revert()
+                EventListener.listenManyRequests:revert()
             end
         )
     end


### PR DESCRIPTION
Basicamente, agora dá pra fazer isso:

```
local ChildClass =
    Class.new(
    {
        listeners = {
            events = {
                Event1 = "method1" --this is a string, the name of a method
            }
        }
    },
    function(self)
    end,
    EventListener
)

function ChildClass:method1()
    --this will execute when "Event1" occurs
end
```