### PR TITLE
Remove useless parameters from events

### DIFF
--- a/Event.lua
+++ b/Event.lua
@@ -151,7 +151,6 @@ function Event.listenRequest(event, method)
     --check if method already has a wrapper (if not, create one)
     local methodWrapper = Event.responderWrappers[method]
     if not methodWrapper then
-        --wrap method to discard the first parameter, since we don't want to pass "__request" to the listener method
         methodWrapper = function(...)
             local results = {method(...)}
 


### PR DESCRIPTION
Antes, se existia um listener para ("Event", "SubEvent"),
e eu fizesse broadcast ("Event", "SubEvent", "Parameter"),
o listener receberia todos os parâmetros ("Event", "SubEvent", "Parameter").

Isso é meio inútil, porque o listener sempre vai ignorar os primeiros parâmetros.
Com essas mudanças, nesse caso o listener vai receber apenas "Parameter".